### PR TITLE
Implementation of RTGOV-380 - Fuse 6 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ RemoteSystemsTempFiles
 .errai
 .classpath
 gwt-unitCache
+.checkstyle

--- a/overlord-rtgov-ui-war-fuse6/pom.xml
+++ b/overlord-rtgov-ui-war-fuse6/pom.xml
@@ -1,0 +1,223 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.overlord.rtgov.ui</groupId>
+    <artifactId>overlord-rtgov-ui</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>overlord-rtgov-ui-war-fuse6</artifactId>
+  <packaging>war</packaging>
+  <name>overlord-rtgov-ui-war-fuse6</name>
+  
+  <dependencies>
+    <!-- The base WAR being extended -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>overlord-rtgov-ui-war-jetty8</artifactId>
+      <version>${project.version}</version>
+      <type>war</type>
+    </dependency>
+
+    <!-- Standard servlet dependencies -->
+    <dependency>
+      <groupId>org.jboss.spec.javax.servlet</groupId>
+      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.overlord</groupId>
+      <artifactId>overlord-commons-osgi</artifactId>
+      <version>${overlord-commons.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    
+    <!-- Some additional dependencies to include in the WAR -->
+    <dependency>
+      <groupId>org.jboss.weld.servlet</groupId>
+      <artifactId>weld-servlet-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.overlord</groupId>
+      <artifactId>overlord-commons-osgi-weld</artifactId>
+      <version>${overlord-commons.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.overlord</groupId>
+      <artifactId>overlord-commons-errai-fuse-support</artifactId>
+      <version>${overlord-commons.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.overlord</groupId>
+      <artifactId>overlord-commons-auth</artifactId>
+      <version>${overlord-commons.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.overlord</groupId>
+      <artifactId>overlord-commons-auth-jetty8</artifactId>
+      <version>${overlord-commons.version}</version>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>regex-property</id>
+            <goals>
+              <goal>regex-property</goal>
+            </goals>
+            <configuration>
+              <name>project.version.osgi</name>
+              <value>${project.version}</value>
+              <regex>-SNAPSHOT</regex>
+              <replacement>.Snapshot</replacement>
+              <failIfNoMatch>false</failIfNoMatch>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <configuration>
+          <warName>overlord-rtgov-ui-war-fuse6</warName>
+          <overlays>
+            <overlay>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>overlord-rtgov-ui-war-jetty8</artifactId>
+              <excludes>
+                <exclude>WEB-INF/lib/log4j-*.jar</exclude>
+                <exclude>WEB-INF/lib/slf4j-api-*.jar</exclude>
+                <exclude>WEB-INF/lib/slf4j-ext-*.jar</exclude>
+                <exclude>WEB-INF/lib/slf4j-log4j12-*.jar</exclude>
+                <exclude>WEB-INF/lib/cal10n-api-*.jar</exclude>
+                <exclude>WEB-INF/lib/overlord-commons-auth-*.jar</exclude>
+              </excludes>
+            </overlay>
+          </overlays>
+          <archive>
+            <manifestEntries>
+              <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
+              <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+              <Bundle-Version>${project.version.osgi}</Bundle-Version>
+              <Bundle-Name>${project.name}</Bundle-Name>
+              <Web-ContextPath>/rtgov-ui</Web-ContextPath>
+              <Webapp-Context>/rtgov-ui</Webapp-Context>
+              <Import-Package>
+javax.servlet,
+javax.servlet.http,
+javax.servlet.jsp,
+javax.security.auth.login,
+javax.xml.parsers,
+javax.xml.bind,
+javax.xml.bind.annotation,
+javax.xml.datatype,
+javax.xml.transform,
+javax.xml.transform.stream,
+javax.xml.namespace,
+javax.xml.xpath,
+javax.ws.rs,
+javax.ws.rs.core,
+javax.ws.rs.ext,
+javax.imageio,
+javax.el,
+javax.imageio.plugins.jpeg,
+javax.net.ssl,
+org.osgi.framework,
+org.osgi.framework.wiring,
+org.xml.sax,
+org.xml.sax.helpers,
+org.w3c.dom,
+org.apache.karaf.jaas.boot.principal,
+javax.security.auth.callback,
+org.eclipse.jetty.plus.jaas,
+org.eclipse.jetty.servlet,
+org.eclipse.jetty.server.handler,
+org.slf4j,
+org.slf4j.cal10n,
+org.slf4j.ext,
+ch.qos.cal10n,
+org.overlord.commons.osgi.vfs
+              </Import-Package>
+              <Bundle-ClassPath>
+.,
+WEB-INF/classes,
+WEB-INF/lib/activation-${version.javax.activation}.jar,
+WEB-INF/lib/aopalliance-1.0.jar,
+WEB-INF/lib/cdi-api-${version.javax.enterprise.cdi}.jar,
+WEB-INF/lib/commons-codec-${version.commons-codec}.jar,
+WEB-INF/lib/commons-collections-${version.commons-collections}.jar,
+WEB-INF/lib/commons-configuration-${version.commons-configuration}.jar,
+WEB-INF/lib/commons-io-${version.commons-io}.jar,
+WEB-INF/lib/commons-lang-${version.commons-lang}.jar,
+WEB-INF/lib/commons-lang3-${commons.lang3.version}.jar,
+WEB-INF/lib/commons-logging-${version.commons-logging}.jar,
+WEB-INF/lib/commons-logging-api-1.1.jar,
+WEB-INF/lib/dom4j-${version.dom4j}.jar,
+WEB-INF/lib/errai-bus-${version.org.jboss.errai}.jar,
+WEB-INF/lib/errai-cdi-client-${version.org.jboss.errai}.jar,
+WEB-INF/lib/errai-cdi-jetty-${version.org.jboss.errai}.jar,
+WEB-INF/lib/errai-codegen-${version.org.jboss.errai}.jar,
+WEB-INF/lib/errai-codegen-gwt-${version.org.jboss.errai}.jar,
+WEB-INF/lib/errai-common-${version.org.jboss.errai}.jar,
+WEB-INF/lib/errai-config-${version.org.jboss.errai}.jar,
+WEB-INF/lib/errai-ioc-${version.org.jboss.errai}.jar,
+WEB-INF/lib/errai-ioc-bus-support-${version.org.jboss.errai}.jar,
+WEB-INF/lib/errai-marshalling-${version.org.jboss.errai}.jar,
+WEB-INF/lib/errai-navigation-${version.org.jboss.errai}.jar,
+WEB-INF/lib/errai-tools-${version.org.jboss.errai}.jar,
+WEB-INF/lib/errai-ui-${version.org.jboss.errai}.jar,
+WEB-INF/lib/errai-weld-integration-${version.org.jboss.errai}.jar,
+WEB-INF/lib/geronimo-spec-jta-1.0.1B-rc4.jar,
+WEB-INF/lib/guava-${version.com.google.guava}.jar,
+WEB-INF/lib/guice-3.0.jar,
+WEB-INF/lib/hsqldb-1.8.0.7.jar,
+WEB-INF/lib/jackson-core-asl-${version.org.codehaus.jackson}.jar,
+WEB-INF/lib/jackson-mapper-asl-${version.org.codehaus.jackson}.jar,
+WEB-INF/lib/javassist-${version.org.javassist}.jar,
+WEB-INF/lib/javax.inject-${version.javax.inject}.jar,
+WEB-INF/lib/jboss-interceptors-api_1.1_spec-1.0.0.Beta1.jar,
+WEB-INF/lib/jboss-logging-${version.org.jboss.logging}.jar,
+WEB-INF/lib/jgroups-${version.org.jgroups}.jar,
+WEB-INF/lib/jsoup-1.7.1.jar,
+WEB-INF/lib/jsr250-api-1.0.jar,
+WEB-INF/lib/jsr305-1.3.9.jar,
+WEB-INF/lib/lesscss-1.3.3.jar,
+WEB-INF/lib/mail-${version.javax.mail}.jar,
+WEB-INF/lib/mvel2-${version.org.mvel}.jar,
+WEB-INF/lib/netty-4.0.0.Alpha1.errai.r1.jar,
+WEB-INF/lib/org.apache.stanbol.enhancer.engines.htmlextractor-0.10.0.jar,
+WEB-INF/lib/overlord-commons-auth-${overlord-commons.version}.jar,
+WEB-INF/lib/overlord-commons-auth-jetty8-${overlord-commons.version}.jar,
+WEB-INF/lib/overlord-commons-config-${overlord-commons.version}.jar,
+WEB-INF/lib/overlord-commons-gwt-${overlord-commons.version}.jar,
+WEB-INF/lib/overlord-commons-uiheader-${overlord-commons.version}.jar,
+WEB-INF/lib/picketbox-4.0.7.Final.jar,
+WEB-INF/lib/picketlink-core-${picketlink.version}.jar,
+WEB-INF/lib/rdf.core-0.12-incubating.jar,
+WEB-INF/lib/reflections-${version.org.jboss.errai}.jar,
+WEB-INF/lib/rhino-${version.rhino.js}.jar,
+WEB-INF/lib/rtgov-ui-core-${project.version}.jar,
+WEB-INF/lib/utils-0.1-incubating.jar,
+WEB-INF/lib/weld-api-${version.org.jboss.weld.weld-api}.jar,
+WEB-INF/lib/weld-core-${version.org.jboss.weld.weld}.jar,
+WEB-INF/lib/weld-se-core-${version.org.jboss.weld.weld}.jar,
+WEB-INF/lib/weld-servlet-core-${version.org.jboss.weld.weld}.jar,
+WEB-INF/lib/weld-spi-${version.org.jboss.weld.weld-api}.jar,
+WEB-INF/lib/wymiwyg-commons-core-0.7.6.jar,
+WEB-INF/lib/overlord-commons-errai-fuse-support-${overlord-commons.version}.jar,
+WEB-INF/lib/overlord-commons-osgi-weld-${overlord-commons.version}.jar,
+WEB-INF/lib/overlord-commons-auth-${overlord-commons.version}.jar,
+WEB-INF/lib/overlord-commons-auth-jetty8-${overlord-commons.version}.jar
+              </Bundle-ClassPath>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/overlord-rtgov-ui-war-fuse6/src/main/features/features.xml
+++ b/overlord-rtgov-ui-war-fuse6/src/main/features/features.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
+
+   <!-- All Runtime Governance dependencies -->
+   <feature name="rtgov-ui-dependencies" version="1.0.0-SNAPSHOT">
+      <feature>http</feature>
+      <bundle>mvn:commons-io/commons-io/2.1</bundle>
+      <bundle>mvn:org.slf4j/slf4j-ext/1.7.1</bundle>
+      <bundle>mvn:ch.qos.cal10n/cal10n-api/0.7.4</bundle>
+      <bundle>mvn:org.overlord/overlord-commons-osgi/2.0.1-SNAPSHOT</bundle>
+      <bundle>mvn:org.overlord/overlord-commons-services/2.0.1-SNAPSHOT</bundle>
+   </feature>
+
+   <!-- The Runtime Governance UI (web app) -->
+   <feature name="rtgov-ui" version="1.0.0-SNAPSHOT">
+      <feature>war</feature>
+      <feature version="1.0.0-SNAPSHOT">rtgov-ui-dependencies</feature>
+      <bundle>mvn:org.overlord.rtgov.ui/overlord-rtgov-ui-war-fuse6/1.0.0-SNAPSHOT/war</bundle>
+   </feature>
+
+</features>

--- a/overlord-rtgov-ui-war-fuse6/src/main/java/org/overlord/rtgov/ui/server/fuse6/Listener.java
+++ b/overlord-rtgov-ui-war-fuse6/src/main/java/org/overlord/rtgov/ui/server/fuse6/Listener.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.overlord.rtgov.ui.server.fuse6;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletRequestEvent;
+import javax.servlet.http.HttpSessionEvent;
+
+import org.jboss.weld.servlet.api.ServletListener;
+import org.overlord.commons.osgi.weld.BundleListener;
+
+/**
+ * A servlet listener that wraps the Weld servlet listener so that we can
+ * fix up the context class loader during creation.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class Listener implements ServletListener {
+
+    private ContextClassLoaderSwapper swapper;
+    private org.jboss.weld.environment.servlet.Listener delegate;
+
+    /**
+     * Constructor.
+     */
+    public Listener() {
+        swapper = new ContextClassLoaderSwapper();
+        delegate = new BundleListener();
+        swapper.restore();
+    }
+
+    private static final class ContextClassLoaderSwapper {
+        private ClassLoader loader = null;
+
+        /**
+         * Constructor.
+         */
+        public ContextClassLoaderSwapper() {
+            loader = Thread.currentThread().getContextClassLoader();
+            Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+        }
+
+        /**
+         * Restores the classloader to its previous version.
+         */
+        public void restore() {
+            Thread.currentThread().setContextClassLoader(loader);
+        }
+    }
+
+    /**
+     * @see javax.servlet.ServletContextListener#contextDestroyed(javax.servlet.ServletContextEvent)
+     */
+    @Override
+    public void contextDestroyed(ServletContextEvent arg0) {
+        delegate.contextDestroyed(arg0);
+    }
+
+    /**
+     * @see javax.servlet.ServletContextListener#contextInitialized(javax.servlet.ServletContextEvent)
+     */
+    @Override
+    public void contextInitialized(ServletContextEvent arg0) {
+        delegate.contextInitialized(arg0);
+    }
+
+    /**
+     * @see javax.servlet.ServletRequestListener#requestDestroyed(javax.servlet.ServletRequestEvent)
+     */
+    @Override
+    public void requestDestroyed(ServletRequestEvent arg0) {
+        delegate.requestDestroyed(arg0);
+    }
+
+    /**
+     * @see javax.servlet.ServletRequestListener#requestInitialized(javax.servlet.ServletRequestEvent)
+     */
+    @Override
+    public void requestInitialized(ServletRequestEvent arg0) {
+        delegate.requestInitialized(arg0);
+    }
+
+    /**
+     * @see javax.servlet.http.HttpSessionListener#sessionCreated(javax.servlet.http.HttpSessionEvent)
+     */
+    @Override
+    public void sessionCreated(HttpSessionEvent arg0) {
+        delegate.sessionCreated(arg0);
+    }
+
+    /**
+     * @see javax.servlet.http.HttpSessionListener#sessionDestroyed(javax.servlet.http.HttpSessionEvent)
+     */
+    @Override
+    public void sessionDestroyed(HttpSessionEvent arg0) {
+        delegate.sessionDestroyed(arg0);
+    }
+
+}

--- a/overlord-rtgov-ui-war-fuse6/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/overlord-rtgov-ui-war-fuse6/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,0 +1,10 @@
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+<!--   <Set name="serverClasses"> -->
+<!--     <Array type="java.lang.String"> -->
+<!--       <Item> -->
+<!--         -org.eclipse.jetty.servlet.ServletContextHandler.Decorator -->
+<!--       </Item> -->
+<!--     </Array> -->
+<!--   </Set> -->
+</Configure>

--- a/overlord-rtgov-ui-war-fuse6/src/main/webapp/WEB-INF/web.xml
+++ b/overlord-rtgov-ui-war-fuse6/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+      version="3.0"> 
+
+  <listener>
+    <listener-class>org.overlord.rtgov.ui.server.fuse6.Listener</listener-class>
+  </listener>
+
+  <filter>
+    <filter-name>HttpRequestThreadLocalFilter</filter-name>
+    <filter-class>org.overlord.commons.auth.jetty8.HttpRequestThreadLocalFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>HttpRequestThreadLocalFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+  
+  <error-page>
+    <error-code>403</error-code>
+    <location>/403.html</location>
+  </error-page>
+
+  <!-- Filters -->
+  <filter>
+    <filter-name>GWTCacheControl</filter-name>
+    <filter-class>org.overlord.commons.gwt.server.filters.GWTCacheControlFilter</filter-class>
+  </filter>
+  <filter>
+    <filter-name>ResourceCacheControl</filter-name>
+    <filter-class>org.overlord.commons.gwt.server.filters.ResourceCacheControlFilter</filter-class>
+  </filter>
+  <filter>
+    <filter-name>LocaleFilter</filter-name>
+    <filter-class>org.overlord.rtgov.ui.server.filters.LocaleFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>GWTCacheControl</filter-name>
+    <url-pattern>/app/*</url-pattern>
+  </filter-mapping>
+  <filter-mapping>
+    <filter-name>ResourceCacheControl</filter-name>
+    <url-pattern>/css/*</url-pattern>
+  </filter-mapping>
+  <filter-mapping>
+    <filter-name>ResourceCacheControl</filter-name>
+    <url-pattern>/images/*</url-pattern>
+  </filter-mapping>
+  <filter-mapping>
+    <filter-name>ResourceCacheControl</filter-name>
+    <url-pattern>/js/*</url-pattern>
+  </filter-mapping>
+  <filter-mapping>
+    <filter-name>LocaleFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+  <filter>
+    <filter-name>OverlordHeaderResources</filter-name>
+    <filter-class>org.overlord.commons.ui.header.OverlordHeaderResources</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>OverlordHeaderResources</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+  <!-- Servlets -->
+  <servlet>
+    <servlet-name>ErraiServlet</servlet-name>
+    <servlet-class>org.jboss.errai.bus.server.servlet.DefaultBlockingServlet</servlet-class>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>ErraiServlet</servlet-name>
+    <url-pattern>*.erraiBus</url-pattern>
+  </servlet-mapping>
+
+  <servlet>
+    <servlet-name>OverlordHeaderDataJS</servlet-name>
+    <servlet-class>org.overlord.commons.ui.header.OverlordHeaderDataJS</servlet-class>
+    <init-param>
+        <param-name>app-id</param-name>
+        <param-value>rtgov-ui</param-value>
+    </init-param>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>OverlordHeaderDataJS</servlet-name>
+    <url-pattern>/js/overlord-header-data.js</url-pattern>
+  </servlet-mapping>
+
+  <resource-env-ref>
+    <description>Object factory for the CDI Bean Manager</description>
+    <resource-env-ref-name>BeanManager</resource-env-ref-name>
+    <resource-env-ref-type>javax.enterprise.inject.spi.BeanManager</resource-env-ref-type>
+  </resource-env-ref>
+
+  <context-param>
+    <param-name>errai.properties</param-name>
+    <param-value>/WEB-INF/errai.properties</param-value>
+  </context-param>
+  <context-param>
+    <param-name>login.config</param-name>
+    <param-value>/WEB-INF/login.config</param-value>
+  </context-param>
+  <context-param>
+    <param-name>users.properties</param-name>
+    <param-value>/WEB-INF/users.properties</param-value>
+  </context-param>
+  
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>RuntimeGovernance</web-resource-name>
+      <url-pattern>/*</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>overlorduser</role-name>
+    </auth-constraint>
+  </security-constraint>
+
+  <login-config>
+    <auth-method>BASIC</auth-method>
+    <realm-name>karaf</realm-name>
+  </login-config>
+
+  <security-role>
+    <role-name>overlorduser</role-name>
+  </security-role>
+
+  <welcome-file-list>
+    <welcome-file>index.html</welcome-file>
+  </welcome-file-list>
+  
+</web-app>

--- a/overlord-rtgov-ui-war-jetty8/pom.xml
+++ b/overlord-rtgov-ui-war-jetty8/pom.xml
@@ -1,0 +1,160 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.overlord.rtgov.ui</groupId>
+    <artifactId>overlord-rtgov-ui</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>overlord-rtgov-ui-war-jetty8</artifactId>
+  <packaging>war</packaging>
+  <name>overlord-rtgov-ui-war-jetty8</name>
+  <dependencies>
+    <!-- The UI WAR's classes -->
+    <dependency>
+      <groupId>org.overlord.rtgov.ui</groupId>
+      <artifactId>overlord-rtgov-ui-war</artifactId>
+      <version>${project.version}</version>
+      <classifier>classes</classifier>
+      <scope>provided</scope>
+    </dependency>
+    
+    <!-- The base WAR being extended -->
+    <dependency>
+      <groupId>org.overlord.rtgov.ui</groupId>
+      <artifactId>overlord-rtgov-ui-war</artifactId>
+      <version>${project.version}</version>
+      <type>war</type>
+    </dependency>
+
+    <!-- Other Jetty-only dependencies -->
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.overlord</groupId>
+      <artifactId>overlord-commons-auth-jetty8</artifactId>
+      <version>${overlord-commons.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.picketlink</groupId>
+      <artifactId>picketlink-core</artifactId>
+      <version>${picketlink.version}</version>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <configuration>
+          <warName>overlord-rtgov-ui-jetty8</warName>
+          <overlays>
+            <overlay>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>overlord-rtgov-ui-war</artifactId>
+              <excludes>
+                <exclude>WEB-INF/lib/jetty-naming-*.jar</exclude>
+                <exclude>WEB-INF/lib/jetty-plus-*.jar</exclude>
+
+                <!-- Don't need these for the mock version -->
+                <exclude>WEB-INF/lib/rtgov-common-*.jar</exclude>
+                <exclude>WEB-INF/lib/rtgov-jbossas-*.jar</exclude>
+                <exclude>WEB-INF/lib/rtgov-ui-services-switchyard-*.jar</exclude>
+                <exclude>WEB-INF/lib/rtgov-ui-situations-*.jar</exclude>
+                <exclude>WEB-INF/lib/situation-store-jpa-*.jar</exclude>
+
+              </excludes>
+            </overlay>
+          </overlays>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>test-jetty</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.7</version>
+            <dependencies>
+              <dependency>
+                <groupId>org.apache.ant</groupId>
+                <artifactId>ant</artifactId>
+                <version>1.8.2</version>
+              </dependency>
+            </dependencies>
+            <executions>
+              <execution>
+                <id>run-jetty8</id>
+                <phase>install</phase>
+                <configuration>
+                  <tasks>
+                    <antversion property="antversion" />
+                    <echo>Ant Version: ${antversion}</echo>
+                    
+                    <property name="appserver.id" value="jetty8" />
+                    <property name="rtgovui.tempdir" value="${project.build.directory}/_tmp" />
+                    <property name="rtgovui.install.dir" value="${project.build.directory}" />
+                    <property name="rtgovui.appserver.dir" location="${rtgovui.install.dir}/jetty-distribution-8.1.14.v20131031" />
+                    <property name="rtgovui.jetty.download.url" value="http://eclipse.org/downloads/download.php?file=/jetty/8.1.14.v20131031/dist/jetty-distribution-8.1.14.v20131031.zip&amp;r=1" />
+                    <property name="rtgovui.jetty.zip" location="${rtgovui.tempdir}/jetty-distribution-8.1.14.v20131031.zip" />
+                    <property name="rtgovui.uiwar-jetty8.war" value="${basedir}/target/overlord-rtgov-ui-jetty8.war" />
+                    <property name="rtgovui.jetty.home" location="${rtgovui.appserver.dir}" />
+                    <property name="rtgovui.jetty.webapps" location="${rtgovui.appserver.dir}/webapps" />
+                    <property name="rtgovui.jetty.logdir" location="${rtgovui.appserver.dir}/logs" />
+                    <property name="rtgovui.main.dir" location="${basedir}/src/main" />
+                    
+                    <echo></echo>
+                    <echo>********************************************************************</echo>
+                    <echo>WAR Path:          ${rtgovui.uiwar-jetty8.war}</echo>
+                    <echo>Jetty Home:        ${rtgovui.jetty.home}</echo>
+                    <echo>********************************************************************</echo>
+                    <echo></echo>
+                    
+                    <mkdir dir="${rtgovui.tempdir}"/>
+                    <delete dir="${rtgovui.jetty.logdir}" />
+                    <mkdir dir="${rtgovui.jetty.logdir}"/>
+
+                    <!-- Download Jetty 8 and Unpack it -->
+                    <get src="${rtgovui.jetty.download.url}" dest="${rtgovui.tempdir}/jetty-distribution-8.1.14.v20131031.zip" usetimestamp="true" />
+                    <unzip src="${rtgovui.jetty.zip}" dest="${rtgovui.install.dir}" overwrite="false" />
+                    <makeurl file="${rtgovui.jetty.home}" property="rtgovui.jetty.home.url"/>
+                    <echo>Jetty Home URL:    ${rtgovui.jetty.home.url}</echo>
+
+                    <!-- Deploy rtgovui to Jetty 8 -->
+                    <copy file="${rtgovui.main.dir}/config/jetty/etc/jetty.xml" todir="${rtgovui.jetty.home}/etc" overwrite="true" /> 
+                    <copy file="${rtgovui.main.dir}/config/jetty/etc/realm.properties" todir="${rtgovui.jetty.home}/etc" overwrite="true" /> 
+                    <copy file="${rtgovui.main.dir}/config/jetty/etc/jetty-logging.xml" todir="${rtgovui.jetty.home}/etc" overwrite="true" /> 
+                    <copy file="${rtgovui.uiwar-jetty8.war}" tofile="${rtgovui.jetty.webapps}/rtgov-ui.war" overwrite="true" /> 
+                    
+                    <!-- Start Jetty 8 -->
+                    <java jar="${rtgovui.jetty.home}/start.jar" fork="true" failonerror="true" dir="${rtgovui.jetty.home}">
+                      <sysproperty key="jetty.home" value="${rtgovui.jetty.home}"/>
+                      <sysproperty key="jetty.home.url" value="${rtgovui.jetty.home.url}"/>
+                      <sysproperty key="java.io.tmpdir" value="${rtgovui.tempdir}"/>
+                      <sysproperty key="org.overlord.apps.config-dir" value="${rtgovui.resources.dir}/config/header"/>
+                      <jvmarg line="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8787" />
+                      <arg value="etc/jetty-logging.xml"/>
+                      <arg value="etc/jetty-started.xml"/>
+                    </java>
+                  </tasks>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/overlord-rtgov-ui-war-jetty8/src/main/config/header/rtgov-ui-overlordapp.properties
+++ b/overlord-rtgov-ui-war-jetty8/src/main/config/header/rtgov-ui-overlordapp.properties
@@ -1,0 +1,5 @@
+overlordapp.primary-brand=JBoss Overlord
+overlordapp.secondary-brand=Runtime Governance
+overlordapp.app-id=rtgov-ui
+overlordapp.label=Runtime Governance
+overlordapp.href=/rtgov-ui

--- a/overlord-rtgov-ui-war-jetty8/src/main/config/jetty/etc/jetty-logging.xml
+++ b/overlord-rtgov-ui-war-jetty8/src/main/config/jetty/etc/jetty-logging.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+
+
+<!-- =============================================================== -->
+<!-- Configure stderr and stdout to a Jetty rollover log file        -->
+<!-- this configuration file should be used in combination with      -->
+<!-- other configuration files.  e.g.                                -->
+<!--    java -jar start.jar etc/jetty-logging.xml                    -->
+<!-- =============================================================== -->
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+
+    <New id="ServerLog" class="java.io.PrintStream">
+      <Arg>
+        <New class="org.eclipse.jetty.util.RolloverFileOutputStream">
+          <Arg><Property name="jetty.logs" default="./logs"/>/yyyy_mm_dd.stderrout.log</Arg>
+          <Arg type="boolean">false</Arg>
+          <Arg type="int">90</Arg>
+          <Arg><Call class="java.util.TimeZone" name="getTimeZone"><Arg>GMT</Arg></Call></Arg>
+          <Get id="ServerLogName" name="datedFilename"/>
+        </New>
+      </Arg>
+    </New>
+
+<!--     <Call class="org.eclipse.jetty.util.log.Log" name="info"><Arg>Redirecting stderr/stdout to <Ref id="ServerLogName"/></Arg></Call> -->
+<!--     <Call class="java.lang.System" name="setErr"><Arg><Ref id="ServerLog"/></Arg></Call> -->
+<!--     <Call class="java.lang.System" name="setOut"><Arg><Ref id="ServerLog"/></Arg></Call> -->
+
+</Configure>
+
+
+

--- a/overlord-rtgov-ui-war-jetty8/src/main/config/jetty/etc/jetty.xml
+++ b/overlord-rtgov-ui-war-jetty8/src/main/config/jetty/etc/jetty.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+
+<!-- =============================================================== -->
+<!-- Configure the Jetty Server -->
+<!-- -->
+<!-- Documentation of this file format can be found at: -->
+<!-- http://wiki.eclipse.org/Jetty/Reference/jetty.xml_syntax -->
+<!-- -->
+<!-- Additional configuration files are available in $JETTY_HOME/etc -->
+<!-- and can be mixed in. For example: -->
+<!-- java -jar start.jar etc/jetty-ssl.xml -->
+<!-- -->
+<!-- See start.ini file for the default configuraton files -->
+<!-- =============================================================== -->
+
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+
+  <Call name="addBean">
+    <Arg>
+      <New class="org.eclipse.jetty.security.HashLoginService">
+        <Set name="name">OverlordRealm</Set>
+        <Set name="config"><SystemProperty name="jetty.home.url" default="." />/etc/realm.properties</Set>
+        <Set name="refreshInterval">0</Set>
+      </New>
+    </Arg>
+  </Call>
+
+  <!-- =========================================================== -->
+  <!-- Server Thread Pool -->
+  <!-- =========================================================== -->
+  <Set name="ThreadPool">
+    <!-- Default queued blocking threadpool -->
+    <New class="org.eclipse.jetty.util.thread.QueuedThreadPool">
+      <Set name="minThreads">10</Set>
+      <Set name="maxThreads">200</Set>
+      <Set name="detailedDump">false</Set>
+    </New>
+  </Set>
+
+  <!-- =========================================================== -->
+  <!-- Set connectors -->
+  <!-- =========================================================== -->
+
+  <Call name="addConnector">
+    <Arg>
+      <New class="org.eclipse.jetty.server.nio.SelectChannelConnector">
+        <Set name="host">
+          <Property name="jetty.host" />
+        </Set>
+        <Set name="port">
+          <Property name="jetty.port" default="8080" />
+        </Set>
+        <Set name="maxIdleTime">300000</Set>
+        <Set name="Acceptors">2</Set>
+        <Set name="statsOn">false</Set>
+        <Set name="confidentialPort">8443</Set>
+        <Set name="lowResourcesConnections">20000</Set>
+        <Set name="lowResourcesMaxIdleTime">5000</Set>
+      </New>
+    </Arg>
+  </Call>
+
+  <!-- =========================================================== -->
+  <!-- Set handler Collection Structure -->
+  <!-- =========================================================== -->
+  <Set name="handler">
+    <New id="Handlers" class="org.eclipse.jetty.server.handler.HandlerCollection">
+      <Set name="handlers">
+        <Array type="org.eclipse.jetty.server.Handler">
+          <Item>
+            <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection" />
+          </Item>
+          <Item>
+            <New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler" />
+          </Item>
+        </Array>
+      </Set>
+    </New>
+  </Set>
+
+  <!-- =========================================================== -->
+  <!-- extra options -->
+  <!-- =========================================================== -->
+  <Set name="stopAtShutdown">true</Set>
+  <Set name="sendServerVersion">true</Set>
+  <Set name="sendDateHeader">true</Set>
+  <Set name="gracefulShutdown">1000</Set>
+  <Set name="dumpAfterStart">false</Set>
+  <Set name="dumpBeforeStop">false</Set>
+  
+  <Set class="org.eclipse.jetty.util.resource.Resource"
+     name="defaultUseCaches">false</Set>
+
+</Configure>

--- a/overlord-rtgov-ui-war-jetty8/src/main/config/jetty/etc/realm.properties
+++ b/overlord-rtgov-ui-war-jetty8/src/main/config/jetty/etc/realm.properties
@@ -1,0 +1,17 @@
+#
+# This file defines users passwords and roles for a HashUserRealm
+#
+# The format is
+#  <username>: <password>[,<rolename> ...]
+#
+# Passwords may be clear text, obfuscated or checksummed.  The class 
+# org.eclipse.util.Password should be used to generate obfuscated
+# passwords or password checksums
+#
+# If DIGEST Authentication is used, the password must be in a recoverable
+# format, either plain text or OBF:.
+#
+admin: admin,overlorduser
+eric: eric,overlorduser
+gary: gary,overlorduser
+mike: mike,overlorduser

--- a/overlord-rtgov-ui-war-jetty8/src/main/webapp/WEB-INF/jetty-env.xml
+++ b/overlord-rtgov-ui-war-jetty8/src/main/webapp/WEB-INF/jetty-env.xml
@@ -1,0 +1,24 @@
+<!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//DTD Configure//EN"
+        "http://jetty.mortbay.org/configure.dtd">
+
+<Configure id="sample-weld" class="org.mortbay.jetty.webapp.WebAppContext">
+
+    <Array id="plusConfig" type="java.lang.String">
+        <Item>org.mortbay.jetty.webapp.WebInfConfiguration</Item>
+        <Item>org.mortbay.jetty.plus.webapp.EnvConfiguration</Item>
+        <Item>org.mortbay.jetty.plus.webapp.Configuration</Item>
+        <Item>org.mortbay.jetty.webapp.JettyWebXmlConfiguration</Item>
+    </Array>
+
+    <New id="BeanManager" class="org.mortbay.jetty.plus.naming.Resource">
+        <Arg><Ref id="sample-weld"/></Arg>
+        <Arg>BeanManager</Arg>
+        <Arg>
+            <New class="javax.naming.Reference">
+                <Arg>javax.enterprise.inject.spi.BeanManager</Arg>
+                <Arg>org.jboss.weld.resources.ManagerObjectFactory</Arg>
+                <Arg/>
+            </New>
+        </Arg>
+    </New>
+</Configure>

--- a/overlord-rtgov-ui-war-jetty8/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/overlord-rtgov-ui-war-jetty8/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,0 +1,14 @@
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+
+  <Get name="securityHandler">
+    <Set name="realmName">OverlordRealm</Set>
+    <Set name="sessionRenewedOnAuthentication">false</Set>
+  </Get>
+
+  <Set name="serverClasses">
+    <Array type="java.lang.String">
+      <Item>-org.eclipse.jetty.servlet.ServletContextHandler.Decorator</Item>
+    </Array>
+  </Set>
+</Configure>

--- a/overlord-rtgov-ui-war-jetty8/src/main/webapp/WEB-INF/web.xml
+++ b/overlord-rtgov-ui-war-jetty8/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+      version="3.0"> 
+
+  <listener>
+    <listener-class>org.jboss.weld.environment.servlet.Listener</listener-class>
+  </listener>
+
+  <filter>
+    <filter-name>HttpRequestThreadLocalFilter</filter-name>
+    <filter-class>org.overlord.commons.auth.jetty8.HttpRequestThreadLocalFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>HttpRequestThreadLocalFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+  
+  <error-page>
+    <error-code>403</error-code>
+    <location>/403.html</location>
+  </error-page>
+
+  <!-- Filters -->
+  <filter>
+    <filter-name>GWTCacheControl</filter-name>
+    <filter-class>org.overlord.commons.gwt.server.filters.GWTCacheControlFilter</filter-class>
+  </filter>
+  <filter>
+    <filter-name>ResourceCacheControl</filter-name>
+    <filter-class>org.overlord.commons.gwt.server.filters.ResourceCacheControlFilter</filter-class>
+  </filter>
+  <filter>
+    <filter-name>LocaleFilter</filter-name>
+    <filter-class>org.overlord.rtgov.ui.server.filters.LocaleFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>GWTCacheControl</filter-name>
+    <url-pattern>/app/*</url-pattern>
+  </filter-mapping>
+  <filter-mapping>
+    <filter-name>ResourceCacheControl</filter-name>
+    <url-pattern>/css/*</url-pattern>
+  </filter-mapping>
+  <filter-mapping>
+    <filter-name>ResourceCacheControl</filter-name>
+    <url-pattern>/images/*</url-pattern>
+  </filter-mapping>
+  <filter-mapping>
+    <filter-name>ResourceCacheControl</filter-name>
+    <url-pattern>/js/*</url-pattern>
+  </filter-mapping>
+  <filter-mapping>
+    <filter-name>LocaleFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+  <!-- Servlets -->
+  <servlet>
+    <servlet-name>ErraiServlet</servlet-name>
+    <servlet-class>org.jboss.errai.bus.server.servlet.DefaultBlockingServlet</servlet-class>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>ErraiServlet</servlet-name>
+    <url-pattern>*.erraiBus</url-pattern>
+  </servlet-mapping>
+
+  <servlet>
+    <servlet-name>OverlordHeaderDataJS</servlet-name>
+    <servlet-class>org.overlord.commons.ui.header.OverlordHeaderDataJS</servlet-class>
+    <init-param>
+        <param-name>app-id</param-name>
+        <param-value>rtgov-ui</param-value>
+    </init-param>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>OverlordHeaderDataJS</servlet-name>
+    <url-pattern>/js/overlord-header-data.js</url-pattern>
+  </servlet-mapping>
+
+  <resource-env-ref>
+    <description>Object factory for the CDI Bean Manager</description>
+    <resource-env-ref-name>BeanManager</resource-env-ref-name>
+    <resource-env-ref-type>javax.enterprise.inject.spi.BeanManager</resource-env-ref-type>
+  </resource-env-ref>
+
+  <context-param>
+    <param-name>errai.properties</param-name>
+    <param-value>/WEB-INF/errai.properties</param-value>
+  </context-param>
+  <context-param>
+    <param-name>login.config</param-name>
+    <param-value>/WEB-INF/login.config</param-value>
+  </context-param>
+  <context-param>
+    <param-name>users.properties</param-name>
+    <param-value>/WEB-INF/users.properties</param-value>
+  </context-param>
+  
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>RuntimeGovernance</web-resource-name>
+      <url-pattern>/*</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>overlorduser</role-name>
+    </auth-constraint>
+  </security-constraint>
+
+  <login-config>
+    <auth-method>BASIC</auth-method>
+    <realm-name>OverlordRealm</realm-name>
+  </login-config>
+
+  <security-role>
+    <role-name>overlorduser</role-name>
+  </security-role>
+
+</web-app>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
 
     <!-- Third party libraries -->
     <overlord-commons.version>2.0.1-SNAPSHOT</overlord-commons.version>
+    <picketlink.version>2.1.6.Final</picketlink.version>
     <commons.io.version>2.4</commons.io.version>
     <commons.lang3.version>3.1</commons.lang3.version>
     <commons.config.version>1.8</commons.config.version>
@@ -98,6 +99,8 @@
 	<module>overlord-rtgov-ui-dev-server</module>
 	<module>overlord-rtgov-ui-war-eap61</module>
 	<module>tests</module>
+	<module>overlord-rtgov-ui-war-jetty8</module>
+	<module>overlord-rtgov-ui-war-fuse6</module>
   </modules>
 
   <scm>


### PR DESCRIPTION
Issue Link:  https://issues.jboss.org/browse/RTGOV-380

Some considerations:
- I added two new modules, one for Jetty 8 and one for Fuse 6.  
  
  > The Jetty 8 module also comes with a handy little maven profile that will download Jetty and install the Jetty 8 WAR into it.  The profile is "test-jetty" and lives in the -jetty8 module.
- In order to properly integrate with Fuse logging I needed to pull a couple of JARs out of the UI WAR and install them as bundles.  
  
  > The result is that there is a "features.xml" file in -fuse6/src/main/features which includes all of the required bundles I needed to deploy and run the UI in Fuse 6.  Note that this features.xml should instead be dynamically created - the file currently checked in should serve only as an example.
- The implementation is not complete - it is a good starting point.  For example it only uses the mock versions of the services.
